### PR TITLE
Fixed undefined index error

### DIFF
--- a/src/KieskeurigManager.php
+++ b/src/KieskeurigManager.php
@@ -74,7 +74,7 @@ class KieskeurigManager
             $data = ($this->xmlToArray($return));
 
             $productList = [];
-            $products = ($data['resultset']['searchresult']['items']['product']);
+            $products = array_get($data, 'resultset.searchresult.items.product', []);
             foreach ($products as $product) {
                 $specifications = $this->getProductSpecifications($product['specification'] ?? []);
 


### PR DESCRIPTION
This PR solves the undefined index 'product' error that we see in the logs of Xingo CMS.